### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # dwm
-A personal fork of dwm-6.2, kind of based on lukesmithxyz's and samedamci's forks.  
-The main aim of the fork is ***A E S T H E T I C S***.   
+A personal fork of dwm-6.2, kind of based on lukesmithxyz's and with ideas from samedamci's forks.
 I'm trying to replicate my i3's looks in dwm.
-## ***If you haven't used dwm, you don't start with this.***  
-Go to [suckless' dwm page](https://dwm.suckless.org) or use [Luke's](https://github.com/LukeSmithxyz/dwm) or [Samedamci's](https://github.com/samedamci/dwm) forks.  
+## ***If you haven't used dwm, you don't start with this.***
+Go to [suckless' dwm page](https://dwm.suckless.org) or use [Luke's](https://github.com/LukeSmithxyz/dwm) or [Samedamci's](https://github.com/samedamci/dwm) forks.
 **_This fork has and probably will have utterly awful coding_, and the features are tailored to my usage, though i hope you'll have fun trying it.**
 ## Features & Patches(mostly patches from suckless):
 - Kinda compatible with pywal (use 'xdotool key super+shift+F5' at the end of the wallpaper changer script)

--- a/config.h
+++ b/config.h
@@ -98,11 +98,11 @@ static Key keys[] = {
 	/*{ MODKEY,                       XK_w,      spawn,          SHCMD("$BROWSER")},*/
 	/*{ MODKEY|ShiftMask,             XK_w,      spawn,          SHCMD("urxvt -e nmtui")},*/
 	/*{ MODKEY,                       XK_r,      spawn,          SHCMD("urxvt -e ranger")},*/
-	{ MODKEY,                       XK_t,      setlayout,      {.v = &layouts[0]} },
+	/*{ MODKEY,                       XK_t,      setlayout,      {.v = &layouts[0]} },
 	{ MODKEY,                       XK_z,      setlayout,      {.v = &layouts[1]} },
 	{ MODKEY,                       XK_u,      setlayout,      {.v = &layouts[2]} },
 	{ MODKEY,                       XK_i,      setlayout,      {.v = &layouts[3]} },
-	{ MODKEY|ShiftMask,             XK_i,      setlayout,      {.v = &layouts[4]} },
+	{ MODKEY|ShiftMask,             XK_i,      setlayout,      {.v = &layouts[4]} },i*/
 	{ MODKEY|ControlMask,		XK_comma,  cyclelayout,    {.i = -1 } },
 	{ MODKEY|ControlMask,           XK_period, cyclelayout,    {.i = +1 } },
 	{ MODKEY,                       XK_s,      togglesticky,   {0} },


### PR DESCRIPTION
Removed shortcuts for layouts, they can still be circled through META+CTRL+, and . 